### PR TITLE
Alternate directory structures

### DIFF
--- a/.stag.php
+++ b/.stag.php
@@ -1,3 +1,0 @@
-<?php
-
-define("BASE_PATH", dirname("_add-ons"));

--- a/.stag.php
+++ b/.stag.php
@@ -1,0 +1,3 @@
+<?php
+
+define("BASE_PATH", dirname("_add-ons"));

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ some sort of version control, then stag might not be for you... yet. Testers wel
 ## Installing
 1. Download the repo, unzip and drop the stag directory into your
 \_add-ons. _(You'll need to rename stag-master to stag)_
-2. Copy \_add-ons/stag/.stag.php to your site root and edit the `BASE_PATH` if necessary.
+2. If your Statamic installation isn't in the root folder, create `.stag.php` in your root and tell Stag the path to your add-ons directory.  
 _For example, if you keep your Statamic installation in ~/Sites/mysite/public_html,
 you should change the line to:_
 
@@ -35,10 +35,18 @@ you should change the line to:_
 ### Using stag
 You need to add the stag bin directory to your $PATH. In your
 .bash_profile (or your prefrerred shell's config) drop in this
-line (you may need to tweak the path depending on your structure):
+line:
 
 ```
 export PATH=$PATH:_add-ons/stag/bin
+```
+
+You may need to tweak the path depending on your structure.
+
+_For example, if you keep your Statamic installation in ~/Sites/mysite/public_html, you should change the line to
+
+```
+export PATH=$PATH:public_html/_add-ons/stag/bin
 ```
 
 Reload your config file:

--- a/README.md
+++ b/README.md
@@ -22,12 +22,20 @@ you aren't comfortable with the command line, or your site isn't under
 some sort of version control, then stag might not be for you... yet. Testers welcome!
 
 ## Installing
-Download the repo, unzip and drop the stag directory into your
+1. Download the repo, unzip and drop the stag directory into your
 \_add-ons. _(You'll need to rename stag-master to stag)_
+2. Copy \_add-ons/stag/.stag.php to your site root and edit the `BASE_PATH` if necessary.
+_For example, if you keep your Statamic installation in ~/Sites/mysite/public_html,
+you should change the line to:_
+
+```
+define("BASE_PATH", dirname("public_html/_add-ons"));
+```
 
 ### Using stag
 You need to add the stag bin directory to your $PATH. In your
-.bash_profile (or your prefrerred shell's config) drop in this line:
+.bash_profile (or your prefrerred shell's config) drop in this
+line (you may need to tweak the path depending on your structure):
 
 ```
 export PATH=$PATH:_add-ons/stag/bin

--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ some sort of version control, then stag might not be for you... yet. Testers wel
 _For example, if you keep your Statamic installation in ~/Sites/mysite/public_html,
 you should change the line to:_
 
-```
-define("BASE_PATH", dirname("public_html/_add-ons"));
-```
+  ```
+  define("BASE_PATH", dirname("public_html/_add-ons"));
+  ```
 
 ### Using stag
 You need to add the stag bin directory to your $PATH. In your

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ export PATH=$PATH:_add-ons/stag/bin
 
 You may need to tweak the path depending on your structure.
 
-_For example, if you keep your Statamic installation in ~/Sites/mysite/public_html, you should change the line to
+_For example, if you keep your Statamic installation in ~/Sites/mysite/public_html, you should change the line to:_
 
 ```
 export PATH=$PATH:public_html/_add-ons/stag/bin

--- a/bin/stag
+++ b/bin/stag
@@ -4,7 +4,13 @@
 
 // start measuring
 define("STATAMIC_START", microtime(true));
-require_once '.stag.php';
+
+if (file_exists('.stag.php')) {
+  require_once '.stag.php';
+} else {
+  define("BASE_PATH", dirname("_add-ons"));
+}
+
 define("APP_PATH", BASE_PATH . "/_app");
 
 // setting this now so that we can do things before the configurations are fully loaded

--- a/bin/stag
+++ b/bin/stag
@@ -4,7 +4,7 @@
 
 // start measuring
 define("STATAMIC_START", microtime(true));
-define("BASE_PATH", dirname("_add-ons"));
+require_once '.stag.php';
 define("APP_PATH", BASE_PATH . "/_app");
 
 // setting this now so that we can do things before the configurations are fully loaded
@@ -53,4 +53,3 @@ $stag->run($action, $opts);
 exit(0);
 
 ?>
-


### PR DESCRIPTION
By default, Stag won't work with how I set up my Statamic sites, because my dir structure looks like this:

```
~/Sites/mysite/
  public_html/
    _add-ons;
    _app/
    …
  dist/
  package.json
  Gruntfile.js
  …
```

I imagine there are other people who have other structures that Stag doesn't fit with w/o tweaking this path. I think it'd be good to have a documented way of defining `BASE_PATH` and any future constants that may need to be tweaked.

My quick and dirty solution was to create a config file (`~/Sites/mysite/.stag.php`) that defines the `BASE_PATH` constant and uses a `require_once` in `bin/stag`.
